### PR TITLE
feat: Add wiki link to the header

### DIFF
--- a/ChaosInitiative.Web.HomePage/NavbarHomePage.cs
+++ b/ChaosInitiative.Web.HomePage/NavbarHomePage.cs
@@ -12,7 +12,7 @@ namespace ChaosInitiative.Web.HomePage
                 {"/engine", "Chaos Source"}, 
                 {"/games", "Games"},
                 {"/contact", "Contact"},
-                //{"/wiki", "Wiki"}
+                {"https://chaosinitiative.github.io/Wiki/", "Wiki"}
             };
 
             return dictionary;


### PR DESCRIPTION
Readds the wiki link to the Chaos Initiative webpage and links it to our new wiki.